### PR TITLE
Fixed OS X build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ cmake_minimum_required(VERSION 2.8)
 
 find_package(CUDA REQUIRED)
 
+if(APPLE)
+	# Fix CUDA+Clang compatibility
+	SET(CUDA_NVCC_FLAGS -ccbin;/usr/bin/clang)
+endif()
+
 option(CUDPP_BUILD_SHARED_LIBS
   "On to build shared libraries, off for static libraries."
   OFF


### PR DESCRIPTION
Current OS X versions no longer include GCC, and without this change you get a "Invalid argument -dumpspecs" message.
