### PR TITLE
fix incompatibility  with cub 1.7 releases

### DIFF
--- a/src/cudpp/app/multisplit_app.cu
+++ b/src/cudpp/app/multisplit_app.cu
@@ -23,6 +23,7 @@
  * @{
  */
 #include <cub/cub.cuh>
+#include <cub/util_allocator.cuh>
 #include "cuda_util.h"
 #include "cudpp.h"
 #include "cudpp_util.h"


### PR DESCRIPTION
compilation errors:
./src/cudpp/app/multisplit_app.cu(1919): error: namespace "cub" has no member "CachingDeviceAllocator"

1 error detected in the compilation of "/tmp/tmpxft_00007947_00000000-7_multisplit_app.cpp1.ii".
CMake Error at cudpp_generated_multisplit_app.cu.o.cmake:264 (message):
  Error generating file
  ./build/src/cudpp/CMakeFiles/cudpp.dir/app/./cudpp_generated_multisplit_app.cu.o


make[2]: *** [src/cudpp/CMakeFiles/cudpp.dir/app/./cudpp_generated_multisplit_app.cu.o] Error 1
make[1]: *** [src/cudpp/CMakeFiles/cudpp.dir/all] Error 2
make: *** [all] Error 2
